### PR TITLE
Partial support for the Dell U2715H

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,17 +17,17 @@ Download app build: `BrightnessMenulet.zip`_.
 
 Monitors:
 .......................
-+------------+------------+
-| Working    | Non-Working|
-+============+============+
-| Dell U2014h| Dell P2715Q| 
-+------------+------------+
-| Dell U2414h|            |
-+------------+------------+
-| Dell U2415h|            | 
-+------------+------------+
-| Dell U2515h|            | 
-+------------+------------+
++------------+------------+------------+
+| Working    | Partial    | Non-Working|
++============+============+============+
+| Dell U2014h| Dell U2715h| Dell P2715Q| 
++------------+------------+------------+
+| Dell U2414h|            |            |
++------------+------------+------------+
+| Dell U2415h|            |            | 
++------------+------------+------------+
+| Dell U2515h|            |            | 
++------------+------------+------------+
 
 If you have tested your monitor(s) with this tool, please let me know whether or not it work and I will update this table.
 


### PR DESCRIPTION
Setting the contrast does not work.
Whenever the slide is modified it sets the display contrast to 25.
