### PR TITLE
Add Acer G276HL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,8 @@ Monitors:
 +-------------+------------+
 | Dell P2415Q |            | 
 +-------------+------------+
+| ACER G276HL |            | 
++-------------+------------+
 
 If you have tested your monitor(s) with this tool, please let me know whether or not it work and I will update this table.
 


### PR DESCRIPTION
Tested my monitor and I can confirm that lowering and raising the brightness and contrast settings work, however default values are not correct. My monitor only goes up to a value of 100 for both the backlight and contrast, but the app upper limit for both is 141 (it seems as though the monitor ignores anything past 100). Also, the current value of the settings on the monitor are not correctly read upon app startup or monitor connection (always defaulting to 127 out of 141). Regardless of these bugs, the core functionality of the app is working. I would open an issue for this but I can't seem to do that here (perhaps because this is a fork?). 

I included some (truncated) debug output as well. VCP goes from 0 to ff.

`2/23/16 10:50:53.301 PM Brightness Menulet[80170]: PreferencesController: Pref Window alloc
2/23/16 10:50:56.289 PM Brightness Menulet[80170]: readDisplay:478179687 withValue: failed need to retry...
2/23/16 10:50:56.289 PM Brightness Menulet[80170]: VCP: 0 - 127 / 141 
2/23/16 10:50:56.290 PM Brightness Menulet[80170]: readDisplay:478179687 withValue: failed need to retry...
2/23/16 10:50:56.290 PM Brightness Menulet[80170]: VCP: 1 - 127 / 141 
2/23/16 10:50:56.291 PM Brightness Menulet[80170]: readDisplay:478179687 withValue: failed need to retry...
2/23/16 10:50:56.291 PM Brightness Menulet[80170]: VCP: 2 - 127 / 141 
2/23/16 10:50:56.292 PM Brightness Menulet[80170]: readDisplay:478179687 withValue: failed need to retry...
`
...
`
2/23/16 10:50:56.417 PM Brightness Menulet[80170]: VCP: fd - 127 / 141 
2/23/16 10:50:56.417 PM Brightness Menulet[80170]: readDisplay:478179687 withValue: failed need to retry...
2/23/16 10:50:56.418 PM Brightness Menulet[80170]: VCP: fe - 127 / 141 
2/23/16 10:50:56.418 PM Brightness Menulet[80170]: readDisplay:478179687 withValue: failed need to retry...
2/23/16 10:50:56.418 PM Brightness Menulet[80170]: VCP: ff - 127 / 141 
2/23/16 10:50:58.718 PM Brightness Menulet[80170]: PreferencesController: preferenceWindow Dealloc
`
