### PR TITLE
BrightnessMenunlet works on BenQ G2410HD

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Brightness Menulet
 Allows you to control monitor brigthness via menu in status bar.
 
 This tool works on OSX 10.8+. In 10.8+, I2C tools are not able to detect monitor buses for communication.
-The main API calls for DDC communication is deprecated so this project could be obselete if Apple 
+The main API calls for DDC communication is deprecated so this project could be obselete if Apple
 completely removes CGDisplayIOServicePort. If you have tested your monitor(s) with this tool, please
 let me know wether it worked or not so I can add monitor models here. Preference's Debug button logs to the
 console VCP codes and their values on the selected monitor.
@@ -21,23 +21,25 @@ Monitors:
 +------------------+---------------+
 | Working          | Non-Working   |
 +==================+===============+
-| Dell U2014h      | Dell P2715Q   | 
+| Dell U2014h      | Dell P2715Q   |
 +------------------+---------------+
 | Dell U2414h      | Philips 4065UC|
 +------------------+---------------+
-| Dell U2415h      | Dell P2412H   | 
+| Dell U2415h      | Dell P2412H   |
 +------------------+---------------+
-| Dell U2515h      |               | 
+| Dell U2515h      |               |
 +------------------+---------------+
-| Dell U2715h      |               | 
+| Dell U2715h      |               |
 +------------------+---------------+
-| Dell U2713HM     |               | 
+| Dell U2713HM     |               |
 +------------------+---------------+
-| Dell P2415Q      |               | 
+| Dell P2415Q      |               |
 +------------------+---------------+
-| Dell S2216M      |               | 
+| Dell S2216M      |               |
 +------------------+---------------+
-| Samsung SA 350   |               | 
+| Samsung SA 350   |               |
++------------------+---------------+
+| BenQ G2410HD     |               | 
 +------------------+---------------+
 
 If you have tested your monitor(s) with this tool, please let me know whether or not it work and I will update this table.


### PR DESCRIPTION
Tested on OS X 10.10.5, connected using adapter miniDP <-> DVI. Both Brightness and Contrast.
